### PR TITLE
Add load-test account - Guilherme Conde #13

### DIFF
--- a/load-tests/guilherme_account.py
+++ b/load-tests/guilherme_account.py
@@ -1,7 +1,5 @@
-from locust import HttpUser, between, task, constant_pacing
-from itertools import count
-
-user_counter = count(1)
+from locust import HttpUser, between, task
+from uuid import uuid4
 
 class AccountLoadUser(HttpUser):
     wait_time = between(1, 5)
@@ -11,30 +9,43 @@ class AccountLoadUser(HttpUser):
     token = None
 
     def on_start(self):
-        user_index = next(user_counter)
-        email = f"load_user_{user_index}@teste.com"
+        unique_id = uuid4().hex
+        email = f"load_user_{unique_id}@teste.com"
 
-        self.client.post("/auth/register", json={
-            "name": f"load_user_{user_index}",
+        register_response = self.client.post("/auth/register", json={
+            "name": f"load_user_{unique_id}",
             "email": email,
             "password": "senha123"
         })
+        if register_response.status_code != 201:
+            self.token = None
+            return
 
-        response = self.client.post("/auth/login", json={
+        login_response = self.client.post("/auth/login", json={
             "email": email,
             "password": "senha123"
         })
+        if login_response.status_code != 200:
+            self.token = None
+            return
 
-        self.token = response.json().get("token")
+        self.token = login_response.json().get("token")
 
-        me = self.client.get("/users/me", headers=self._headers())
-        self.user_id = me.json().get("id")
+        me_response = self.client.get("/users/me", headers=self._headers())
+        if me_response.status_code != 200:
+            self.token = None
+            return
+
+        self.user_id = me_response.json().get("id")
 
     def _headers(self):
         return {"Authorization": f"Bearer {self.token}"}
 
     @task(2)
     def create_account(self):
+        if self.token is None or self.user_id is None:
+            return
+
         response = self.client.post("/accounts", json={
             "bankName": "Banco Carga",
             "accountType": "Poupança",
@@ -42,12 +53,12 @@ class AccountLoadUser(HttpUser):
             "user": {"id": self.user_id}
         }, headers=self._headers())
 
-        data = response.json()
-        if data.get("id"):
-            self.account_id = data.get("id")
+        if response.status_code == 201:
+            self.account_id = response.json().get("id")
 
     @task(1)
     def get_account_by_id(self):
-        if self.account_id is None:
+        if self.token is None or self.account_id is None:
             return
+
         self.client.get(f"/accounts/{self.account_id}", headers=self._headers())


### PR DESCRIPTION
# Análise de Teste de Carga — Modelo: Account refs #13
 
**Modelo testado:** `Account` — contas bancárias da aplicação Fintrack.
 
---
 
## Descrição do teste implementado
 
O teste simula usuários realizando operações completas na API, onde cada usuário:
 
1. Se registra via `POST /auth/register`
2. Faz login via `POST /auth/login` e obtém o token JWT
3. Busca seus dados via `GET /users/me`
4. Cria uma conta bancária via `POST /accounts`
 
Após o setup, cada usuário executa continuamente duas tarefas:
 
- `POST /accounts` — criação de nova conta com peso 2 (escrita no banco)
- `GET /accounts/{id}` — leitura da conta criada com peso 1
 
O teste foi configurado com `wait_time` entre 1 e 5 segundos, **10.000 usuários** e **spawn rate de 500 usuários/segundo**.
 
---
 
## Comportamento observado durante o aumento de carga
 
- O sistema se manteve estável até aproximadamente **500 usuários**
- Com spawn rate de 500/s, a carga atingiu **10.000 usuários** em cerca de 20 segundos
- O pico de RPS chegou a **~270 RPS** com **~200 falhas/s** no momento do spike inicial
- Após o pico, o sistema estabilizou com **0 falhas/s**, porém com latência extremamente alta (~80–90 segundos)
 
---
 
## Momento em que a aplicação começou a apresentar gargalos
 
Os primeiros sinais de degradação surgiram assim que a carga ultrapassou **~2.000 usuários simultâneos**, quando a latência mediana começou a ultrapassar 20 segundos e as primeiras falhas apareceram no `/auth/register`.
 
---
 
## Sintomas observados
 
- Latência mediana global de **65.000ms (65 segundos)**
- Latência média global de **57.170ms**
- Percentil 95 global em **91.000ms**
- Total de **1.708 falhas** em **15.870 requisições** (~10,7% de taxa de erro)
- Todas as falhas concentradas no `POST /auth/register`
 
---
 
## Operação com maior impacto de desempenho
 
| Endpoint | Média (ms) | Mediana (ms) | P95 (ms) | Falhas |
|---|---|---|---|---|
| `GET /users/me` | 85.690 | 87.000 | 92.000 | 0 |
| `POST /accounts` | 88.228 | 89.000 | 91.000 | 0 |
| `POST /auth/login` | 77.406 | 85.000 | 91.000 | 0 |
| `POST /auth/register` | 44.215 | 41.000 | 93.000 | 1.708 |
 
O `POST /auth/register` foi a única operação com falhas (1.708 de 9.900 requisições — ~17% de erro), provavelmente por timeout durante o pico inicial de carga.
 
---
 
## Interpretação sobre o possível motivo do gargalo
 
- **Spawn rate agressivo (500/s)** gerou uma avalanche de registros simultâneos, sobrecarregando o banco logo no início
- **Contenção no banco de dados** por INSERTs concorrentes na tabela de usuários
- **Pool de conexões HikariCP** possivelmente esgotado durante o pico, causando filas de espera que elevaram a latência de todos os endpoints para ~80–90 segundos
- Com o código corrigido (uuid4), os erros 409 por email duplicado foram eliminados — as falhas restantes são de timeout
 
---
 
## Conclusão
 
A aplicação demonstrou comportamento:
 
- ✅ Estável até cerca de **500–800 usuários** simultâneos
- ⚠️ Degradação significativa a partir de **~2.000 usuários**
- ❌ Latência inaceitável (~80s) acima de **10.000 usuários**
 
Para suportar maior carga em produção, recomenda-se:
 
- Aumentar o pool de conexões do HikariCP
- Implementar cache de autenticação para reduzir pressão sobre o banco em picos de login
- Considerar escalabilidade horizontal
- Revisar a estratégia de spawn rate nos testes para simular crescimento mais gradual