### PR TITLE
Load-test account - João #13

### DIFF
--- a/load-tests/joao_account.py
+++ b/load-tests/joao_account.py
@@ -1,0 +1,66 @@
+from locust import HttpUser, between, task
+from uuid import uuid4
+
+
+class AccountLoadUser(HttpUser):
+    wait_time = between(1, 3)
+    account_id = None
+    user_id = None
+    token = None
+
+    def on_start(self):
+        unique_id = uuid4().hex
+        email = f"load_user_{unique_id}@teste.com"
+
+        register_response = self.client.post("/auth/register", json={
+            "name": f"load_user_{unique_id}",
+            "email": email,
+            "password": "senha123"
+        })
+
+        if register_response.status_code != 201:
+            self.token = None
+            return
+
+        login_response = self.client.post("/auth/login", json={
+            "email": email,
+            "password": "senha123"
+        })
+
+        if login_response.status_code != 200:
+            self.token = None
+            return
+
+        self.token = login_response.json().get("token")
+
+        me_response = self.client.get("/users/me", headers=self._headers())
+        if me_response.status_code != 200:
+            self.token = None
+            return
+
+        self.user_id = me_response.json().get("id")
+
+    def _headers(self):
+        return {"Authorization": f"Bearer {self.token}"}
+
+    @task(2)
+    def create_account(self):
+        if self.token is None or self.user_id is None:
+            return
+
+        response = self.client.post("/accounts", json={
+            "bankName": "Banco Carga",
+            "accountType": "Poupança",
+            "balance": 500.00,
+            "user": {"id": self.user_id}
+        }, headers=self._headers())
+
+        if response.status_code == 201:
+            self.account_id = response.json().get("id")
+
+    @task(1)
+    def get_account_by_id(self):
+        if self.token is None or self.account_id is None:
+            return
+
+        self.client.get(f"/accounts/{self.account_id}", headers=self._headers())


### PR DESCRIPTION
# Análise de Teste de Carga — Modelo: Account
 
**Modelo testado:** `Account` — contas bancárias da aplicação Fintrack.
 
## Descrição do teste implementado
 
O teste simula usuários realizando operações completas na API, onde cada usuário:
 
1. Se registra via `POST /auth/register`
2. Faz login via `POST /auth/login` e obtém o token JWT
3. Busca seus dados via `GET /users/me`
 
Após o setup, cada usuário executa continuamente duas tarefas:
- `POST /accounts` — criação de nova conta com peso 2 (escrita no banco)
- `GET /accounts/{id}` — leitura da conta criada com peso 1
 
O teste foi configurado com `wait_time` entre 1 e 3 segundos, **5.000 usuários** e spawn rate de **250 usuários/segundo**.
 
---
 
## Comportamento observado durante o aumento de carga
 
- O sistema se manteve estável até aproximadamente **800 usuários** (até ~21:01:00), com latência próxima de zero e RPS crescendo organicamente
- Com spawn rate de 250/s, a carga atingiu 5.000 usuários em cerca de **20 segundos** (entre 21:01:00 e 21:01:20)
- O pico de RPS chegou a **~45 RPS** em 21:01:40, imediatamente após a carga se estabilizar em 5.000 usuários
- Após o pico, o RPS caiu bruscamente para ~10–17 RPS, indicando que o sistema entrou em colapso parcial e passou a processar requisições em fila com altíssima latência
 
---
 
## Momento em que a aplicação começou a apresentar gargalos
 
Os primeiros sinais de degradação surgiram em **~21:01:20**, quando a carga ultrapassou ~2.000 usuários simultâneos. A partir desse ponto, a latência mediana (P50) disparou de 0 para mais de 10.000ms e nunca se recuperou, seguindo uma **tendência crescente e contínua** até o fim do teste, atingindo ~110.000ms ao final.
 
---
 
## Sintomas observados
 
| Métrica | Valor |
|---|---|
| Latência mediana global (P50) | 20.000ms |
| Latência P95 global | 65.000ms |
| Latência P99 global | 78.000ms |
| Média global | 26.246ms |
| Máximo registrado | 81.056ms |
| Total de falhas | 3 em 1.709 requisições (~0,17%) |
| RPS no pico | ~45 RPS |
| RPS após colapso | ~10–17 RPS |
 
- Latência com **crescimento contínuo** sem estabilização — sinal de fila crescente no servidor
- RPS caindo após o pico indica que o servidor não consegue processar novas requisições na velocidade em que chegam
- Falhas esparsas (apenas 3) sugerem que o sistema preferiu atrasar a rejeitar — comportamento de timeout tardio
 
---
 
## Operação com maior impacto de desempenho
 
| Endpoint | Média (ms) | Mediana (ms) | P95 (ms) | P99 (ms) | Falhas |
|---|---|---|---|---|---|
| `POST /auth/login` | 26.374 | 21.000 | 54.000 | 62.000 | 1 |
| `POST /auth/register` | 25.091 | 18.000 | 70.000 | 79.000 | 0 |
| `GET /users/me` | 48.800 | 50.000 | 65.000 | 66.000 | 2 |
 
O **`GET /users/me`** apresentou a maior latência mediana (50.000ms) e foi responsável por 2 das 3 falhas, sendo a operação com maior impacto relativo ao volume de requisições — apenas 53 chamadas, mas com latência média de ~48,8 segundos. O `POST /auth/register` teve o maior volume (1.097 req) com latência mais baixa, indicando que as escritas no banco aceitaram fila melhor do que as leituras autenticadas.
 
---
 
## Interpretação sobre o possível motivo do gargalo
 
- **Spawn rate agressivo (250/s)** gerou uma avalanche de registros em ~20 segundos, sobrecarregando o banco logo na rampa de subida
- A **latência crescente sem estabilização** (visível no gráfico de Response Times) é o sintoma clássico de **pool de conexões esgotado** — as requisições entram em fila esperando uma conexão livre do HikariCP
- O `GET /users/me` ter latência mais alta que os POSTs sugere **contenção em leitura com JOIN ou validação de token** que compete com as escritas concorrentes pelo mesmo pool
- O fato de o RPS ter caído após o pico (de ~45 para ~12) indica que o servidor processou as requisições enfileiradas lentamente, sem recuperação — característico de **saturação de threads ou conexões de banco**
 
---
 
## Conclusão
 
A aplicação demonstrou o seguinte comportamento:
 
- ✅ **Estável** até cerca de 800–1.000 usuários simultâneos
- ⚠️ **Degradação significativa** a partir de ~2.000 usuários (21:01:20)
- ❌ **Latência inaceitável** (>20s mediana, >100s P95 ao final) com 5.000 usuários
 
Em comparação com o teste de referência (10.000 usuários, spawn 500/s), este teste com metade dos usuários e spawn mais moderado produziu **menos falhas absolutas (3 vs 1.708)**, porém com latência igualmente elevada — confirmando que o gargalo é estrutural no pool de conexões do banco, não apenas resultado do spike inicial.
 
Para suportar maior carga em produção, recomenda-se:
- Aumentar o pool de conexões do HikariCP
- Implementar cache para o endpoint `/users/me` (validação de token em memória)
- Considerar read replicas para separar carga de leitura e escrita
- Revisar índices na tabela de usuários para otimizar as queries de autenticação