### PR TITLE
feat: add AuditWorker + AsyncConfig + modificado-UserController #20

### DIFF
--- a/src/main/java/com/guimarobo/Fintrack/FintrackApplication.java
+++ b/src/main/java/com/guimarobo/Fintrack/FintrackApplication.java
@@ -2,8 +2,10 @@ package com.guimarobo.Fintrack;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableAsync;
 
 @SpringBootApplication
+@EnableAsync
 public class FintrackApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/guimarobo/Fintrack/config/AsyncConfig.java
+++ b/src/main/java/com/guimarobo/Fintrack/config/AsyncConfig.java
@@ -1,0 +1,24 @@
+package com.guimarobo.Fintrack.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+import java.util.concurrent.Executor;
+import java.util.concurrent.ThreadPoolExecutor;
+
+@Configuration
+public class AsyncConfig {
+
+    @Bean(name = "auditPool")
+    public Executor auditPool() {
+        ThreadPoolTaskExecutor exec = new ThreadPoolTaskExecutor();
+        exec.setCorePoolSize(2);
+        exec.setMaxPoolSize(5);
+        exec.setQueueCapacity(20);
+        exec.setThreadNamePrefix("audit-worker-");
+        exec.setRejectedExecutionHandler(new ThreadPoolExecutor.CallerRunsPolicy());
+        exec.initialize();
+        return exec;
+    }
+}

--- a/src/main/java/com/guimarobo/Fintrack/controller/UserController.java
+++ b/src/main/java/com/guimarobo/Fintrack/controller/UserController.java
@@ -2,6 +2,7 @@ package com.guimarobo.Fintrack.controller;
 
 import com.guimarobo.Fintrack.model.User;
 import com.guimarobo.Fintrack.service.UserService;
+import com.guimarobo.Fintrack.worker.AuditWorker;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
@@ -13,37 +14,59 @@ import java.util.Map;
 public class UserController {
 
     private final UserService userService;
+    private final AuditWorker auditWorker;
 
-    public UserController(UserService userService) {
+    public UserController(UserService userService, AuditWorker auditWorker) {
         this.userService = userService;
+        this.auditWorker = auditWorker;
     }
 
-    // GET - Buscar dados do próprio usuário autenticado
     @GetMapping("/me")
     public ResponseEntity<User> getAuthenticatedUser(@AuthenticationPrincipal User user) {
         return ResponseEntity.ok(userService.findById(user.getId()));
     }
 
-    // PUT - Atualizar dados do próprio usuário autenticado
     @PutMapping("/me")
     public ResponseEntity<User> updateAuthenticatedUser(@AuthenticationPrincipal User user,
                                                         @RequestBody User updatedUser) {
         User savedUser = userService.update(user.getId(), updatedUser);
+
+        // dispara auditoria em background — response já foi pro cliente
+        auditWorker.registrarAuditoria(
+                user.getId(),
+                "PUT /users/me",
+                "nome atualizado para: " + savedUser.getName()
+        );
+
         return ResponseEntity.ok(savedUser);
     }
 
-    // PATCH - Atualizar parcialmente dados do próprio usuário autenticado
     @PatchMapping("/me")
     public ResponseEntity<User> patchAuthenticatedUser(@AuthenticationPrincipal User user,
                                                        @RequestBody Map<String, String> fields) {
         User updatedUser = userService.patch(user.getId(), fields);
+
+        auditWorker.registrarAuditoria(
+                user.getId(),
+                "PATCH /users/me",
+                "campos alterados: " + fields.keySet()
+        );
+
         return ResponseEntity.ok(updatedUser);
     }
 
-    // DELETE - Deletar a própria conta
     @DeleteMapping("/me")
     public ResponseEntity<Void> deleteAuthenticatedUser(@AuthenticationPrincipal User user) {
-        userService.delete(user.getId());
+        Long userId = user.getId();
+        userService.delete(userId);
+
+        // captura o ID antes de deletar — user não existe mais depois
+        auditWorker.registrarAuditoria(
+                userId,
+                "DELETE /users/me",
+                "conta removida permanentemente"
+        );
+
         return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/guimarobo/Fintrack/worker/AuditWorker.java
+++ b/src/main/java/com/guimarobo/Fintrack/worker/AuditWorker.java
@@ -1,0 +1,36 @@
+package com.guimarobo.Fintrack.worker;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
+@Service
+@Slf4j
+public class AuditWorker {
+
+    private static final DateTimeFormatter FMT =
+            DateTimeFormatter.ofPattern("dd/MM/yyyy HH:mm:ss");
+
+    @Async("auditPool")
+    public void registrarAuditoria(Long userId, String operacao, String detalhe) {
+        log.info("[AUDIT] iniciando registro — userId={} | operacao={}", userId, operacao);
+
+        try {
+            // simula uma latência real (ex: gravar em arquivo, chamar serviço externo)
+            Thread.sleep(500);
+
+            String timestamp = LocalDateTime.now().format(FMT);
+
+            log.info("[AUDIT] ✓ userId={} | operacao={} | detalhe={} | timestamp={}",
+                    userId, operacao, detalhe, timestamp);
+
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            log.error("[AUDIT] ✗ Falha ao registrar auditoria — userId={} | operacao={} | erro={}",
+                    userId, operacao, e.getMessage());
+        }
+    }
+}


### PR DESCRIPTION
## Modelo: User refs #20 

## Processo assíncrono implementado
Log de auditoria assíncrono disparado após operações de modificação
do usuário autenticado: PUT /users/me, PATCH /users/me e DELETE /users/me.

## Estratégia adotada
@Async com ThreadPoolTaskExecutor (pool: auditPool)

## Justificativa técnica
Auditoria é obrigatória em sistemas financeiros, mas registrar logs
não deve atrasar a resposta ao cliente. O worker roda em thread separada
— o usuário recebe 200 OK imediatamente enquanto o log é processado.

## Fluxo de execução
PUT/PATCH/DELETE /users/me
  → UserController recebe
  → UserService executa (síncrono)
  → Response HTTP retorna ao cliente ✓
  → AuditWorker.registrarAuditoria() dispara via @Async
  → thread separada do auditPool registra o log

## Impacto observado
Tempo de resposta não inclui a latência do registro de auditoria (500ms simulado).
Thread HTTP liberada imediatamente após o save.

## Possíveis falhas ou limitações
- Se o servidor reiniciar durante o processamento, o log se perde (@Async não persiste)
- Sem retry implementado — falha no worker gera apenas log de erro
- Melhoria futura: persistir auditoria em tabela audit_log no banco

## Interpretação do comportamento
O 200 OK chega no cliente antes do log aparecer no console,
comprovando execução em thread separada (auditPool).

## Conclusão
@Async resolve o desacoplamento entre operação principal e side effects
de auditoria. AuditWorker em classe separada é obrigatório para o
proxy do Spring funcionar corretamente.