### PR TITLE
feat: add Transação por categoria + campo category na Transaction #20

### DIFF
--- a/src/main/java/com/guimarobo/Fintrack/config/AsyncConfig.java
+++ b/src/main/java/com/guimarobo/Fintrack/config/AsyncConfig.java
@@ -10,6 +10,18 @@ import java.util.concurrent.ThreadPoolExecutor;
 @Configuration
 public class AsyncConfig {
 
+    @Bean(name = "categorizationPool")
+    public Executor categorizationPool() {
+        ThreadPoolTaskExecutor exec = new ThreadPoolTaskExecutor();
+        exec.setCorePoolSize(2);
+        exec.setMaxPoolSize(5);
+        exec.setQueueCapacity(20);
+        exec.setThreadNamePrefix("fintrack-async-");
+        exec.setRejectedExecutionHandler(new ThreadPoolExecutor.CallerRunsPolicy());
+        exec.initialize();
+        return exec;
+    }
+
     @Bean(name = "auditPool")
     public Executor auditPool() {
         ThreadPoolTaskExecutor exec = new ThreadPoolTaskExecutor();

--- a/src/main/java/com/guimarobo/Fintrack/model/Transaction.java
+++ b/src/main/java/com/guimarobo/Fintrack/model/Transaction.java
@@ -27,6 +27,8 @@ public class Transaction {
     @NotNull(message = "A data é obrigatória.")
     private LocalDate date;
 
+    private String category; // ALIMENTACAO, TRANSPORTE, LAZER, MORADIA, OUTROS
+
     @NotNull(message = "A conta relacionada (account) é obrigatória.")
     @ManyToOne // relacionamento muitos pra um
     @JoinColumn(name = "account_id") // chave estrangeira
@@ -82,6 +84,14 @@ public class Transaction {
 
     public void setDate(LocalDate date) {
         this.date = date;
+    }
+
+    public String getCategory() {
+        return category;
+    }
+
+    public void setCategory(String category) {
+        this.category = category;
     }
 
     public Account getAccount() {

--- a/src/main/java/com/guimarobo/Fintrack/service/TransactionServiceImpl.java
+++ b/src/main/java/com/guimarobo/Fintrack/service/TransactionServiceImpl.java
@@ -6,6 +6,7 @@ import com.guimarobo.Fintrack.model.Transaction;
 import com.guimarobo.Fintrack.model.User;
 import com.guimarobo.Fintrack.repository.AccountRepository;
 import com.guimarobo.Fintrack.repository.TransactionRepository;
+import com.guimarobo.Fintrack.worker.TransactionCategorizationWorker;
 import jakarta.transaction.Transactional;
 import org.springframework.stereotype.Service;
 
@@ -19,11 +20,14 @@ public class TransactionServiceImpl implements TransactionService {
 
     private final TransactionRepository transactionRepository;
     private final AccountRepository accountRepository;
+    private final TransactionCategorizationWorker categorizationWorker;
 
     public TransactionServiceImpl(TransactionRepository transactionRepository,
-                                  AccountRepository accountRepository) {
+                                  AccountRepository accountRepository,
+                                  TransactionCategorizationWorker categorizationWorker) {
         this.transactionRepository = transactionRepository;
         this.accountRepository = accountRepository;
+        this.categorizationWorker = categorizationWorker;
     }
 
     @Override
@@ -55,7 +59,11 @@ public class TransactionServiceImpl implements TransactionService {
         accountRepository.save(account);
 
         transaction.setAccount(account);
-        return transactionRepository.save(transaction);
+        Transaction saved = transactionRepository.save(transaction);
+
+        categorizationWorker.categorizar(saved);
+
+        return saved;
     }
 
     @Override

--- a/src/main/java/com/guimarobo/Fintrack/worker/TransactionCategorizationWorker.java
+++ b/src/main/java/com/guimarobo/Fintrack/worker/TransactionCategorizationWorker.java
@@ -1,0 +1,48 @@
+package com.guimarobo.Fintrack.worker;
+
+import com.guimarobo.Fintrack.model.Transaction;
+import com.guimarobo.Fintrack.repository.TransactionRepository;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+
+@Service
+@Slf4j
+public class TransactionCategorizationWorker {
+
+    private final TransactionRepository transactionRepository;
+
+    public TransactionCategorizationWorker(TransactionRepository transactionRepository) {
+        this.transactionRepository = transactionRepository;
+    }
+
+    @Async("categorizationPool")
+    public void categorizar(Transaction transaction) {
+        try {
+            String desc = transaction.getDescription().toLowerCase();
+            String categoria;
+
+            if (desc.contains("mercado") || desc.contains("supermercado") || desc.contains("padaria")) {
+                categoria = "ALIMENTACAO";
+            } else if (desc.contains("uber") || desc.contains("99") || desc.contains("onibus")) {
+                categoria = "TRANSPORTE";
+            } else if (desc.contains("aluguel") || desc.contains("condominio") || desc.contains("luz")) {
+                categoria = "MORADIA";
+            } else if (desc.contains("cinema") || desc.contains("netflix") || desc.contains("spotify")) {
+                categoria = "LAZER";
+            } else {
+                categoria = "OUTROS";
+            }
+
+            transaction.setCategory(categoria);
+            transactionRepository.save(transaction);
+
+            log.info("Transação ID: {} categorizada como {} (descrição: \"{}\")",
+                    transaction.getId(), categoria, transaction.getDescription());
+
+        } catch (Exception e) {
+            log.error("Falha ao categorizar transação ID: {} — erro: {}",
+                    transaction.getId(), e.getMessage());
+        }
+    }
+}


### PR DESCRIPTION
## Relatório João Gabriel Macedo - Refs #20 

### Modelo utilizado                                                                                                                                                 
**Transaction**: foi adicionado o campo `category` na entidade `Transaction` para armazenar a categoria atribuída automaticamente pelo worker assíncrono.
                                                                                                                                                                       
### Descrição do processo assíncrono
Foi implementado o `TransactionCategorizationWorker`, um worker assíncrono que analisa a descrição de uma transação recém-criada e atribui automaticamente uma categoria (ALIMENTACAO, TRANSPORTE, MORADIA, LAZER ou OUTROS). O objetivo é classificar transações sem bloquear a resposta da API ao usuário, tornando a categorização um processo em segundo plano.               
                                                                                                                                                                       
### Estratégia adotada
**@Async** com um pool de threads dedicado chamado `categorizationPool`, configurado no `AsyncConfig`. O worker é invocado logo após o `save()` da transação no `TransactionServiceImpl`, executando a categorização de forma assíncrona em uma thread separada. 

### Justificativa técnica                                                                                                                                            
A abordagem `@Async` foi escolhida porque a categorização não é crítica para a criação da transação — o usuário não precisa esperar a classificação ser concluído para receber a resposta da API. Usar um pool de threads dedicado (`categorizationPool`) evita concorrência com outras tarefas assíncronas do sistema, como o `AuditWorker` que utiliza o `auditPool`. A estratégia de rejeição `CallerRunsPolicy` garante que, se a fila estiver cheia, a tarefa será executada na thread principal em vez de ser descartada.

### Fluxo de execução                                                                                                                                                
1. O usuário envia uma requisição POST para criar uma transação (ex: descrição "Mercado Extra")
2. O `TransactionServiceImpl.save()` valida os dados, aplica a mudança de saldo na conta e salva a transação no banco                                              
3. Imediatamente após o `save()`, o método `categorizationWorker.categorizar(saved)` é chamado                                                                     
4. Como o método é anotado com `@Async("categorizationPool")`, o Spring o executa em uma thread separada do pool `fintrack-async-`
5. A resposta HTTP é retornada ao usuário **sem esperar** a categorização
6. Na thread assíncrona, o worker analisa a descrição com regras de palavras-chave (ex: "mercado" → ALIMENTACAO) O campo `category` da transação é atualizado e salvo no banco via `transactionRepository.save()`
7. Um log é registrado: `Transação ID: 12 categorizada como ALIMENTACAO (descrição: "Mercado Extra")`                                                             

### Impacto na aplicação
- **Tempo de resposta:** a criação de transações continua com o mesmo tempo de resposta, pois a categorização não bloqueia a thread principal
- **Comportamento:** a transação é criada inicialmente com `category = null` e, milissegundos depois, o campo é atualizado pelo worker. Em uma consulta imediata logo após a criação, o campo pode ainda estar nulo, mas em uso normal já estará preenchido
- **Banco de dados:** foi adicionada a coluna `category` na tabela `transactions`, nullable, sem impacto nas transações já existentes

### Falhas e limitações
- **Categorização por palavras-chave:** as regras são simples e baseadas em `contains()`. Descrições ambíguas ou fora do padrão caem em "OUTROS". Uma melhoria futura seria usar machine learning ou uma API externa.
- **Consistência eventual:** há uma janela muito curta entre a criação da transação e a atribuição da categoria. Se o cliente consultar a transação nesse intervalo, o campo `category` pode ser `null`
- **Falha silenciosa:** se o worker falhar (ex: erro no banco), a transação continua existindo sem categoria. Nenhum dado é perdido, mas a categorização não é retentada automaticamente
- **Sem fila persistente:** se a aplicação for reiniciada enquanto há tarefas na fila do pool, essas tarefas são perdidas. Para cenários de produção, uma fila persistente (RabbitMQ, Kafka) seria mais robusta

### Comportamento do sistema                                                                                                                                         
O sistema se comporta de forma **não bloqueante**. A thread HTTP que atende a requisição do usuário retorna imediatamente após salvar a transação. A categorização ocorre em paralelo no pool `categorizationPool` (2 a 5 threads, fila de 20). Em cenários de alta carga, se a fila encher, a política `CallerRunsPolicy` faz a categorização rodar na thread principal, garantindo que nenhuma tarefa é descartada — apenas perde a característica assíncrona temporariamente.

### Conclusão
A implementação do `TransactionCategorizationWorker` demonstra o uso prático de processamento assíncrono com Spring Boot. A solução é simples, resiliente a falhas (não compromete a criação da transação) e melhora a experiência do usuário ao não adicionar latência na resposta da API. O padrão adotado é extensível — novas regras de categorização podem ser adicionadas ao worker sem impactar o fluxo principal da aplicação.